### PR TITLE
404 if semantic routing without x-nl-examples

### DIFF
--- a/plugins/agent_bridge_config.go
+++ b/plugins/agent_bridge_config.go
@@ -253,7 +253,7 @@ func initPluginFromRequest(r *http.Request) (*PluginDataConfig, error) {
 
 	logConfig()
 
-	logger.Debugf("[+] Finished initPluginFromRequest fror api id: %s", apiID)
+	logger.Debugf("[+] Finished initPluginFromRequest for api id: %s", apiID)
 	return pluginDataConfig, nil
 }
 

--- a/plugins/agent_bridge_endpoint_selection.go
+++ b/plugins/agent_bridge_endpoint_selection.go
@@ -21,7 +21,8 @@ func findSelectOperation(apiId string, input string) (*string, float64, error) {
 	apiSpecIndex, present := apiSpecIndices[apiId]
 	apiSpecIndicesLock.RUnlock()
 	if !present {
-		return nil, 0, fmt.Errorf("no index found for api: %s", apiId)
+		// This API has no x-nl-input-examples
+		return nil, 0, nil
 	}
 	pluginConfigLock.RLock()
 	pluginDataConfig, present := pluginConfig[apiId]


### PR DESCRIPTION
# Description

If we try to do a query involving a semantic routing (`curl http://tyk:8080/github '--header 'Content-Type: application/nlq' -v -d 'Most recent commit on repo ...'`) on an API where is no `x-nl-input-examples`, then there is no index, hence we cannot do a semantic search, hence we return 404 
