### PR TITLE
support Content-encoding: gzip

### DIFF
--- a/plugins/agent_bridge.go
+++ b/plugins/agent_bridge.go
@@ -174,6 +174,16 @@ func RewriteResponseToNl(rw http.ResponseWriter, res *http.Response, req *http.R
 		return
 	}
 
+	if res.Header.Get("Content-Encoding") == "gzip" {
+		bodyBytes, err = GetUnzipContent(bodyBytes)
+		if err != nil {
+			logger.Errorf("[+] Error while unzipping the response body: %s", err)
+			http.Error(rw, INTERNAL_ERROR_MSG, http.StatusInternalServerError)
+			return
+		}
+		res.Header.Del("Content-Encoding")
+	}
+
 	naturalLanguageResponse, err := responseToNL(req, string(bodyBytes))
 	if err != nil {
 		logger.Errorf("[+] Error while converting the response to Natural Language: %s", err)

--- a/plugins/tools.go
+++ b/plugins/tools.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func GetUnzipContent(zipContent []byte) ([]byte, error) {
+	buf := bytes.NewBuffer(zipContent)
+	reader, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+
+	unzippedContent, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return unzippedContent, nil
+}


### PR DESCRIPTION
# Description

Support "Content-Encoding: gzip"  on upstream response: unzip the body before converting to NL