### PR TITLE
Description and summary if there is not x-nl-example

### DIFF
--- a/plugins/agent_bridge_config.go
+++ b/plugins/agent_bridge_config.go
@@ -190,6 +190,22 @@ func initPluginFromRequest(r *http.Request) (*PluginDataConfig, error) {
 		}
 	}
 
+	// If we have no operation with x-nl-input-examples then we rely only on the
+	// descriptions
+	if len(pluginDataConfig.SelectOperations) == 0 {
+		for _, path := range apidef.Paths {
+			for _, operation := range path.Operations() {
+				if operation.OperationID == "" {
+					continue
+				}
+				aiExtentionConfig := &AIExtensionConfig{}
+				aiExtentionConfig.InputExamples = append(aiExtentionConfig.InputExamples, operation.Description)
+				aiExtentionConfig.InputExamples = append(aiExtentionConfig.InputExamples, operation.Summary)
+				pluginDataConfig.SelectOperations[operation.OperationID] = aiExtentionConfig
+			}
+		}
+	}
+
 	if pluginDataConfig.AzureConfig.OpenAIKey == "" {
 		err := fmt.Errorf("Missing required config for azureConfig.openAIKey")
 		logger.Fatalf("[+] Error initializing plugin: %s", err)


### PR DESCRIPTION
# Description

Let's imagine a new user adds a new OpenAPI specification for his service.
He provides no `x-nl-input-examples` at all.

In that case, and only in this case, we rely on the `description` and `summary` fields of the OpenAPI operations.